### PR TITLE
Introduce html-webpack-externals-plugin

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "clean-webpack-plugin": "^0.1.19",
     "eslint": "^5.6.0",
     "eslint-config-google": "^0.10.0",
+    "html-webpack-externals-plugin": "^3.8.0",
     "html-webpack-plugin": "^3.2.0",
     "jest": "^23.6.0",
     "source-map-loader": "^0.2.4",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
     "pythonic": "^1.0.1",
     "react": "^16.5.1",
     "react-dom": "^16.5.1",
-    "react-dom-factories": "^1.0.2",
     "react-redux": "^5.0.7",
     "redux": "^4.0.0",
     "semantic-ui-react": "^0.82.5",

--- a/src/html/index.html
+++ b/src/html/index.html
@@ -10,25 +10,9 @@
     <!-- ag-grid-community 19.0.x -->
     <link rel="stylesheet" href="https://unpkg.com/ag-grid-community@19.0/dist/styles/ag-grid.css">
     <link rel="stylesheet" href="https://unpkg.com/ag-grid-community@19.0/dist/styles/ag-theme-balham.css">
-    <script crossorigin src="https://unpkg.com/ag-grid-community@19.0/dist/ag-grid-community.min.noStyle.js"></script>
-
-    <!-- react 16.5.x -->
-    <script crossorigin src="https://unpkg.com/react@16.5/umd/react.production.min.js"></script>
-
-    <!-- react-dom 16.5.x -->
-    <script crossorigin src="https://unpkg.com/react-dom@16.5/umd/react-dom.production.min.js"></script>
-
-    <!-- react-redux 5.0.7 -->
-    <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/react-redux/5.0.7/react-redux.min.js"></script>
-
-    <!-- redux 4.0.x -->
-    <script crossorigin src="https://unpkg.com/redux@4.0/dist/redux.min.js"></script>
 
     <!-- semantic-ui 2.3.3 -->
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui/2.3.3/semantic.min.css">
-
-    <!-- semantic-ui-react 0.82.5 -->
-    <script crossorigin src="https://cdnjs.cloudflare.com/ajax/libs/semantic-ui-react/0.82.5/semantic-ui-react.min.js"></script>
 </head>
 
 <body>

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -9,7 +9,6 @@ const package = require('./package.json');
 module.exports = (env, argv) => {
   const mode = argv.mode;
 
-  const outputJs = 'bundle.js';
   const outputPath = path.resolve(__dirname, 'dist', mode);
   const srcHtmlIndex = path.resolve(__dirname, 'src', 'html', 'index.html');
   const srcTsIndex = path.resolve(__dirname, 'src', 'ts', 'index.tsx');
@@ -30,7 +29,6 @@ module.exports = (env, argv) => {
       ],
     },
     output: {
-      filename: outputJs,
       path: outputPath,
     },
     plugins: [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -40,11 +40,9 @@ module.exports = (env, argv) => {
     performance: {
       assetFilter: (assetFilename) => {
         if (assetFilename.endsWith('.js.map')) {
-          // disable performance hints for source map
           return false;
         }
         if (assetFilename === 'vender.js') {
-          // disable performance hints for non-standard libraries
           return false;
         }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -103,7 +103,6 @@ module.exports = (env, argv) => {
           // Not use externals for following libraries:
           //   - ag-grid-react
           //   - pythonic
-          //   - react-dom-factories
           //   - ts-deepcopy
           //   - typescript-fsa
           //   - typescript-fsa-reducers

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -48,6 +48,7 @@ module.exports = (env, argv) => {
         },
       }),
       new HtmlWebpackExternalsPlugin({
+        enabled: mode === 'development',
         externals: [
           {
             module: 'ag-grid-community',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -73,62 +73,32 @@ module.exports = (env, argv) => {
           {
             module: 'ag-grid-community',
             global: 'agGrid',
-            entry: {
-              path: 'https://unpkg.com/ag-grid-community@19.0/dist/ag-grid-community.min.noStyle.js',
-              attributes: {
-                crossorigin: 'anonymous',
-              },
-            },
+            entry: 'dist/ag-grid-community.min.noStyle.js',
           },
           {
             module: 'react',
             global: 'React',
-            entry: {
-              path: 'https://unpkg.com/react@16.5/umd/react.production.min.js',
-              attributes: {
-                crossorigin: 'anonymous',
-              },
-            },
+            entry: 'umd/react.production.min.js',
           },
           {
             module: 'react-dom',
             global: 'ReactDOM',
-            entry: {
-              path: 'https://unpkg.com/react-dom@16.5/umd/react-dom.production.min.js',
-              attributes: {
-                crossorigin: 'anonymous',
-              },
-            },
+            entry: 'umd/react-dom.production.min.js',
           },
           {
             module: 'react-redux',
             global: 'ReactRedux',
-            entry: {
-              path: 'https://cdnjs.cloudflare.com/ajax/libs/react-redux/5.0.7/react-redux.min.js',
-              attributes: {
-                crossorigin: 'anonymous',
-              },
-            },
+            entry: 'dist/react-redux.min.js',
           },
           {
             module: 'redux',
             global: 'Redux',
-            entry: {
-              path: 'https://unpkg.com/redux@4.0/dist/redux.min.js',
-              attributes: {
-                crossorigin: 'anonymous',
-              },
-            },
+            entry: 'dist/redux.min.js',
           },
           {
             module: 'semantic-ui-react',
             global: 'semanticUIReact',
-            entry: {
-              path: 'https://cdnjs.cloudflare.com/ajax/libs/semantic-ui-react/0.82.5/semantic-ui-react.min.js',
-              attributes: {
-                crossorigin: 'anonymous',
-              },
-            },
+            entry: 'dist/umd/semantic-ui-react.min.js',
           },
           // Not use externals for following libraries:
           //   - ag-grid-react

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 
 const CleanWebpackPlugin = require('clean-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
+const HtmlWebpackExternalsPlugin = require('html-webpack-externals-plugin');
 
 const package = require('./package.json');
 
@@ -16,20 +17,6 @@ module.exports = (env, argv) => {
   return {
     devtool: 'source-map',
     entry: srcTsIndex,
-    externals: {
-      'ag-grid-community': 'agGrid',
-      'ag-grid-react': false,
-      'pythonic': false,
-      'react': 'React',
-      'react-dom': 'ReactDOM',
-      'react-dom-factories': false,
-      'react-redux': 'ReactRedux',
-      'redux': 'Redux',
-      'semantic-ui-react': 'semanticUIReact',
-      'ts-deepcopy': false,
-      'typescript-fsa': false,
-      'typescript-fsa-reducers': false,
-    },
     module: {
       rules: [
         {
@@ -61,6 +48,77 @@ module.exports = (env, argv) => {
             },
           },
         },
+      }),
+      new HtmlWebpackExternalsPlugin({
+        externals: [
+          {
+            module: 'ag-grid-community',
+            global: 'agGrid',
+            entry: {
+              path: 'https://unpkg.com/ag-grid-community@19.0/dist/ag-grid-community.min.noStyle.js',
+              attributes: {
+                crossorigin: 'anonymous',
+              },
+            },
+          },
+          {
+            module: 'react',
+            global: 'React',
+            entry: {
+              path: 'https://unpkg.com/react@16.5/umd/react.production.min.js',
+              attributes: {
+                crossorigin: 'anonymous',
+              },
+            },
+          },
+          {
+            module: 'react-dom',
+            global: 'ReactDOM',
+            entry: {
+              path: 'https://unpkg.com/react-dom@16.5/umd/react-dom.production.min.js',
+              attributes: {
+                crossorigin: 'anonymous',
+              },
+            },
+          },
+          {
+            module: 'react-redux',
+            global: 'ReactRedux',
+            entry: {
+              path: 'https://cdnjs.cloudflare.com/ajax/libs/react-redux/5.0.7/react-redux.min.js',
+              attributes: {
+                crossorigin: 'anonymous',
+              },
+            },
+          },
+          {
+            module: 'redux',
+            global: 'Redux',
+            entry: {
+              path: 'https://unpkg.com/redux@4.0/dist/redux.min.js',
+              attributes: {
+                crossorigin: 'anonymous',
+              },
+            },
+          },
+          {
+            module: 'semantic-ui-react',
+            global: 'semanticUIReact',
+            entry: {
+              path: 'https://cdnjs.cloudflare.com/ajax/libs/semantic-ui-react/0.82.5/semantic-ui-react.min.js',
+              attributes: {
+                crossorigin: 'anonymous',
+              },
+            },
+          },
+          // Not use externals for following libraries:
+          //   - ag-grid-react
+          //   - pythonic
+          //   - react-dom-factories
+          //   - ts-deepcopy
+          //   - typescript-fsa
+          //   - typescript-fsa-reducers
+        ],
       }),
     ],
     resolve: {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -28,6 +28,12 @@ module.exports = (env, argv) => {
         },
       ],
     },
+    optimization: {
+      splitChunks: {
+        name: 'vender',
+        chunks: 'initial',
+      },
+    },
     output: {
       path: outputPath,
     },

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,33 +72,33 @@ module.exports = (env, argv) => {
         externals: [
           {
             module: 'ag-grid-community',
-            global: 'agGrid',
             entry: 'dist/ag-grid-community.min.noStyle.js',
+            global: 'agGrid',
           },
           {
             module: 'react',
-            global: 'React',
             entry: 'umd/react.production.min.js',
+            global: 'React',
           },
           {
             module: 'react-dom',
-            global: 'ReactDOM',
             entry: 'umd/react-dom.production.min.js',
+            global: 'ReactDOM',
           },
           {
             module: 'react-redux',
-            global: 'ReactRedux',
             entry: 'dist/react-redux.min.js',
+            global: 'ReactRedux',
           },
           {
             module: 'redux',
-            global: 'Redux',
             entry: 'dist/redux.min.js',
+            global: 'Redux',
           },
           {
             module: 'semantic-ui-react',
-            global: 'semanticUIReact',
             entry: 'dist/umd/semantic-ui-react.min.js',
+            global: 'semanticUIReact',
           },
           // Not use externals for following libraries:
           //   - ag-grid-react

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -37,6 +37,20 @@ module.exports = (env, argv) => {
     output: {
       path: outputPath,
     },
+    performance: {
+      assetFilter: (assetFilename) => {
+        if (assetFilename.endsWith('.js.map')) {
+          // disable performance hints for source map
+          return false;
+        }
+        if (assetFilename === 'vender.js') {
+          // disable performance hints for non-standard libraries
+          return false;
+        }
+
+        return true;
+      },
+    },
     plugins: [
       new CleanWebpackPlugin([
         outputPath,
@@ -137,10 +151,6 @@ module.exports = (env, argv) => {
     // Disabled following settings defined in webpack.production.js
     // because it is maybe needless:
     // ```
-    // performance: {
-    //     hints: false
-    // },
-    //
     // plugins: [
     //     new webpack.DefinePlugin({
     //         'process.env.NODE_ENV': JSON.stringify('production')

--- a/yarn.lock
+++ b/yarn.lock
@@ -305,7 +305,7 @@ ajv@^5.3.0:
     fast-json-stable-stringify "^2.0.0"
     json-schema-traverse "^0.3.0"
 
-ajv@^6.0.1, ajv@^6.5.3:
+ajv@^6.0.1, ajv@^6.1.1, ajv@^6.5.3:
   version "6.5.4"
   resolved "https://registry.yarnpkg.com/ajv/-/ajv-6.5.4.tgz#247d5274110db653706b550fcc2b797ca28cfc59"
   integrity sha512-4Wyjt8+t6YszqaXnLDfMmG/8AlO5Zbcsy3ATHncCzjW/NoPzAId8AK6749Ybjmdt+kUY1gP60fCu46oDxPv/mg==
@@ -1220,6 +1220,20 @@ copy-descriptor@^0.1.0:
   resolved "https://registry.yarnpkg.com/copy-descriptor/-/copy-descriptor-0.1.1.tgz#676f6eb3c39997c2ee1ac3a924fd6124748f578d"
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
+copy-webpack-plugin@^4.4.1:
+  version "4.5.4"
+  resolved "https://registry.yarnpkg.com/copy-webpack-plugin/-/copy-webpack-plugin-4.5.4.tgz#f2b2782b3cd5225535c3dc166a80067e7d940f27"
+  integrity sha512-0lstlEyj74OAtYMrDxlNZsU7cwFijAI3Ofz2fD6Mpo9r4xCv4yegfa3uHIKvZY1NSuOtE9nvG6TAhJ+uz9gDaQ==
+  dependencies:
+    cacache "^10.0.4"
+    find-cache-dir "^1.0.0"
+    globby "^7.1.1"
+    is-glob "^4.0.0"
+    loader-utils "^1.1.0"
+    minimatch "^3.0.4"
+    p-limit "^1.0.0"
+    serialize-javascript "^1.4.0"
+
 core-js@^1.0.0:
   version "1.2.7"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
@@ -1506,6 +1520,14 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dir-glob@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-2.0.0.tgz#0b205d2b6aef98238ca286598a8204d29d0a0034"
+  integrity sha512-37qirFDz8cA5fimp9feo43fSuRo2gHwaIn6dXL8Ber1dGwUosDrGZeCCXq57WnIqE4aQ+u3eQZzsk1yOzhdwag==
+  dependencies:
+    arrify "^1.0.1"
+    path-type "^3.0.0"
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -2265,7 +2287,7 @@ glob-parent@^3.1.0:
     is-glob "^3.1.0"
     path-dirname "^1.0.0"
 
-glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2:
+glob@^7.0.3, glob@^7.0.5, glob@^7.1.1, glob@^7.1.2, glob@^7.1.3:
   version "7.1.3"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.3.tgz#3960832d3f1574108342dafd3a67b332c0969df1"
   integrity sha512-vcfuiIxogLV4DlGBHIUOwI0IbrJ8HWPc4MU7HzviGeNho/UJDfi6B5p3sHeWIQ0KGIU0Jpxi5ZHxemQfLkkAwQ==
@@ -2303,6 +2325,18 @@ globby@^5.0.0:
     object-assign "^4.0.1"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+globby@^7.1.1:
+  version "7.1.1"
+  resolved "https://registry.yarnpkg.com/globby/-/globby-7.1.1.tgz#fb2ccff9401f8600945dfada97440cca972b8680"
+  integrity sha1-+yzP+UAfhgCUXfral0QMypcrhoA=
+  dependencies:
+    array-union "^1.0.1"
+    dir-glob "^2.0.0"
+    glob "^7.1.2"
+    ignore "^3.3.5"
+    pify "^3.0.0"
+    slash "^1.0.0"
 
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6:
   version "4.1.11"
@@ -2471,6 +2505,24 @@ html-minifier@^3.2.3:
     relateurl "0.2.x"
     uglify-js "3.4.x"
 
+html-webpack-externals-plugin@^3.8.0:
+  version "3.8.0"
+  resolved "https://registry.yarnpkg.com/html-webpack-externals-plugin/-/html-webpack-externals-plugin-3.8.0.tgz#e3f38419c67b7599e69afab0966a2164d2a3d838"
+  integrity sha512-LYrlPk/F8E+4xXNTVGuePalVx+efBlms3jaDCJE5yXEUBIORdzY5m2CMM45oBAZonUY50htXRsMyMizEbABUjw==
+  dependencies:
+    ajv "^6.1.1"
+    copy-webpack-plugin "^4.4.1"
+    html-webpack-include-assets-plugin "^1.0.2"
+
+html-webpack-include-assets-plugin@^1.0.2:
+  version "1.0.6"
+  resolved "https://registry.yarnpkg.com/html-webpack-include-assets-plugin/-/html-webpack-include-assets-plugin-1.0.6.tgz#c67cb824a0db22382eb36b0ae34a602a8a03db8c"
+  integrity sha512-UG+LE180RabNogyOVo0DTH3Ck9EOguwCSu4IfNf3v/xFjeudeYDOpu/r0VH2Xbt52cMTcEY0gZWTrIP7twPv2w==
+  dependencies:
+    glob "^7.1.3"
+    minimatch "^3.0.4"
+    slash "^2.0.0"
+
 html-webpack-plugin@^3.2.0:
   version "3.2.0"
   resolved "http://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz#b01abbd723acaaa7b37b6af4492ebda03d9dd37b"
@@ -2538,6 +2590,11 @@ ignore-walk@^3.0.1:
   integrity sha512-DTVlMx3IYPe0/JJcYP7Gxg7ttZZu3IInhuEhbchuqneY9wWe5Ojy2mXLBaQFUQmo0AW2r3qG7m1mg86js+gnlQ==
   dependencies:
     minimatch "^3.0.4"
+
+ignore@^3.3.5:
+  version "3.3.10"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-3.3.10.tgz#0a97fb876986e8081c631160f8f9f389157f0043"
+  integrity sha512-Pgs951kaMm5GXP7MOvxERINe3gsaVjUWFm+UZPSq9xYriQAksyhg0csnS0KXSNRD5NmNdapXEpjxG49+AKh/ug==
 
 ignore@^4.0.6:
   version "4.0.6"
@@ -4207,7 +4264,7 @@ p-is-promise@^1.1.0:
   resolved "https://registry.yarnpkg.com/p-is-promise/-/p-is-promise-1.1.0.tgz#9c9456989e9f6588017b0434d56097675c3da05e"
   integrity sha1-nJRWmJ6fZYgBewQ01WCXZ1w9oF4=
 
-p-limit@^1.1.0:
+p-limit@^1.0.0, p-limit@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-1.3.0.tgz#b86bd5f0c25690911c7590fcbfc2010d54b3ccb8"
   integrity sha512-vvcXsLAJ9Dr5rQOPk7toZQZJApBl2K4J6dANSsEuh6QI41JYcsS/qhTGa9ErIUUgK3WNQoJYvylxvjqmiqEA9Q==
@@ -4354,6 +4411,13 @@ path-type@^1.0.0:
     graceful-fs "^4.1.2"
     pify "^2.0.0"
     pinkie-promise "^2.0.0"
+
+path-type@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/path-type/-/path-type-3.0.0.tgz#cef31dc8e0a1a3bb0d105c0cd97cf3bf47f4e36f"
+  integrity sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==
+  dependencies:
+    pify "^3.0.0"
 
 pbkdf2@^3.0.3:
   version "3.0.16"
@@ -5077,6 +5141,11 @@ slash@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/slash/-/slash-1.0.0.tgz#c41f2f6c39fc16d1cd17ad4b5d896114ae470d55"
   integrity sha1-xB8vbDn8FtHNF61LXYlhFK5HDVU=
+
+slash@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/slash/-/slash-2.0.0.tgz#de552851a1759df3a8f206535442f5ec4ddeab44"
+  integrity sha512-ZYKh3Wh2z1PpEXWr0MpSBZ0V6mZHAQfYevttO11c51CaWjGTaadiKZ+wVt1PbMlDV5qhMFslpZCemhwOK7C89A==
 
 slice-ansi@1.0.0:
   version "1.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -4674,11 +4674,6 @@ rc@^1.2.7:
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
 
-react-dom-factories@^1.0.2:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/react-dom-factories/-/react-dom-factories-1.0.2.tgz#eb7705c4db36fb501b3aa38ff759616aa0ff96e0"
-  integrity sha1-63cFxNs2+1AbOqOP91lhaqD/luA=
-
 react-dom@^16.5.1:
   version "16.5.1"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.5.1.tgz#29d0c5a01ed3b6b4c14309aa91af6ec4eb4f292c"


### PR DESCRIPTION
* Use scripts (except stylesheets) in `node_modules` instead of CDN
* Split  bundled script file `bundle.js` into `main.js` and `vender.js`
  * Bundle scripts in `src/` as `main.js`
  * Bundle scripts in `node_modules/` as `vender.js`
    * Skip some scripts and link them directly as html script tag attribute src if mode is `development`