### PR TITLE
Add webpack config to work watch in VirtualBox

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -124,6 +124,9 @@ module.exports = (env, argv) => {
         '.tsx',
       ],
     },
+    watchOptions: {
+      poll: true,
+    },
     // Disabled following settings defined in webpack.production.js
     // because it is maybe needless:
     // ```


### PR DESCRIPTION
https://webpack.js.org/configuration/watch/#watchoptions-poll

> If watching does not work for you, try out this option.
> Watching does not work with NFS and machines in VirtualBox.