### PR TITLE
Ignore npm cache dir as dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 /.git
 /.vscode
+/cache
 /node_modules


### PR DESCRIPTION
#66 で npm のキャッシュを永続化するために
リポジトリ直下に cache ディレクトリを作成するようにしたことで、
docker コンテナ起動時のコピー処理の時間が著しく増大するようになったため
dockerignore に cache を追加する。